### PR TITLE
Wrong expected result in mqtt_client_sup:reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ with correct username/password.
 Full list of client parameters are:
 
 	1> C3 = mqtt_client_simple:connect([
-						{hostname, "localhost"},
+						{host, "localhost"},
 	          {port, 1884},
 	          {username, <<"romeo">>},
 	          {password, <<"1234">>},

--- a/src/mqtt_client_sup.erl
+++ b/src/mqtt_client_sup.erl
@@ -62,7 +62,8 @@ reconnect(Id) ->
 	case supervisor:restart_child(?MODULE, Id) of
 		{ok, Pid} ->
 			{ok, Pid};
-		{error, {already_started, Pid}} ->
+		{error, running} ->
+		        {ok,Pid} = get(Id),
 			{ok, Pid};
 		Error ->
 			Error

--- a/src/mqtt_client_sup.erl
+++ b/src/mqtt_client_sup.erl
@@ -63,7 +63,7 @@ reconnect(Id) ->
 		{ok, Pid} ->
 			{ok, Pid};
 		{error, running} ->
-		        {ok,Pid} = get(Id),
+		        {ok,Pid} = ?MODULE:get(Id),
 			{ok, Pid};
 		Error ->
 			Error


### PR DESCRIPTION
<pre>mqtt_client_sup:reconnect message {error,already_started,Pid} </pre> 

is expected, while supervisor returns only  <pre> {error,running} </pre> according to the documentation. 

fixed message and provide results according to the reconnect specification  <pre>{ok,pid()}</pre>
